### PR TITLE
Features for specific bank format export

### DIFF
--- a/AsciiImportExport.Tests/AsciiImportExport.Tests.csproj
+++ b/AsciiImportExport.Tests/AsciiImportExport.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Pocos\State.cs" />
+    <Compile Include="SpecialityBankFormatTest.cs" />
     <Compile Include="StatesAndTerritoriesTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AsciiImportExport.Tests/SpecialityBankFormatTest.cs
+++ b/AsciiImportExport.Tests/SpecialityBankFormatTest.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace AsciiImportExport.Tests
+{
+    [TestFixture]
+    public class SpecialityBankFormatTest
+    {
+        public class ChequeRow
+        {
+            public enum RecordTypeEnum
+            {
+                Outstanding, Void
+            }
+            public ulong AccountNo { get; set; }
+            public RecordTypeEnum RecordType { get; set; }
+            public ulong SerialNumber { get; set; }
+            public ulong AmountCents { get; set; }
+            public DateTime Date { get; set; }
+        }
+
+        [Test]
+        public void ValuesWithFullWidth_ExportedByFillingOutFullSpace()
+        {
+            var definition = GetDefinition();
+
+            var record = new ChequeRow()
+                {
+                    AccountNo = 123456789012,
+                    RecordType = ChequeRow.RecordTypeEnum.Outstanding,
+                    AmountCents = 210987654321,
+                    SerialNumber = 9876543210,
+                    Date = new DateTime(2013, 12, 31)
+                };
+            var resultString = definition.Build().Export(new ChequeRow[] {record});
+            Assert.That(resultString,
+                        Is.EqualTo("123456789012O987654321021098765432120131231" +
+                                   new string(' ', 1 + 50 + 16 + 256 + 16)));
+
+        }
+        [Test]
+        public void RightJustifiedValues_AreFilledUpWithFillChar()
+        {
+            var definition = GetDefinition();
+
+            var record = new ChequeRow()
+                {
+                    AccountNo = 123456789,
+                    RecordType = ChequeRow.RecordTypeEnum.Outstanding,
+                    AmountCents = 152,
+                    SerialNumber = 123,
+                    Date = new DateTime(2013, 12, 31)
+                };
+            var resultString = definition.Build().Export(new ChequeRow[] {record});
+            Assert.That(resultString,
+                        Is.EqualTo("000123456789O000000012300000000015220131231" +
+                                   new string(' ', 1 + 50 + 16 + 256 + 16)));
+
+        }
+
+        [Test]
+        public void DataOverflowInColumn_ThrowsExportException()
+        {
+            var definition = GetDefinition();
+            var record = new ChequeRow()
+                {
+                    AccountNo = 1234567890123 // Overflowed
+                };
+            var document = definition.Build();
+            Assert.Throws<ExportException>(() => document.Export(new ChequeRow[] {record}));
+
+        }
+
+        private DocumentFormatDefinitionBuilder<ChequeRow> GetDefinition()
+        {
+            var definition = new DocumentFormatDefinitionBuilder<ChequeRow>(string.Empty, false);
+            definition.AddColumn(q => q.AccountNo,
+                                 c => c.SetColumnWidth(12).SetAlignment(ColumnAlignment.Right).SetFillChar('0').ThrowOnOverflow());
+            definition.AddColumn(q => q.RecordType, c => c.SetExportFunc(EnumConvertFunc));
+            definition.AddColumn(q => q.SerialNumber,
+                                 c => c.SetColumnWidth(10).SetAlignment(ColumnAlignment.Right).SetFillChar('0').ThrowOnOverflow());
+            definition.AddColumn(q => q.AmountCents,
+                                 c => c.SetColumnWidth(12).SetAlignment(ColumnAlignment.Right).SetFillChar('0').ThrowOnOverflow());
+            definition.AddColumn(q => q.Date, 
+                                 c => c.SetColumnWidth(8).SetStringFormat("yyyyMMdd"));
+            definition.AddDummyColumn(1);
+            definition.AddDummyColumn(50);
+            definition.AddDummyColumn(16);
+            definition.AddDummyColumn(256);
+            definition.AddDummyColumn(16);
+            definition.SetExportHeaderLine(false);
+            definition.SetTrimLineEnds(false);
+            return definition;
+        }
+
+        private string EnumConvertFunc(ChequeRow arg1, ChequeRow.RecordTypeEnum arg2)
+        {
+            return arg2 == ChequeRow.RecordTypeEnum.Outstanding ? "O" : "I";
+        }
+    }
+}

--- a/AsciiImportExport/DocumentColumnBuilder.cs
+++ b/AsciiImportExport/DocumentColumnBuilder.cs
@@ -27,6 +27,8 @@ namespace AsciiImportExport
         private Func<string, TRet> _importFunc;
         private string _stringFormat;
         private IFormatProvider _provider = CultureInfo.InvariantCulture;
+        private char? _fillChar;
+        private bool _throwOnColumnOverflow;
 
         /// <summary>
         /// The constructor
@@ -43,7 +45,7 @@ namespace AsciiImportExport
         /// <returns></returns>
         public IDocumentColumn<T> Build()
         {
-            return new DocumentColumn<T, TRet>(_expression, _header, _defaultValue, _columnWidth, _alignment, _stringFormat, _provider, _booleanTrue, _booleanFalse, _importFunc, _exportFunc);
+            return new DocumentColumn<T, TRet>(_expression, _header, _defaultValue, _columnWidth, _alignment, _stringFormat, _provider, _booleanTrue, _booleanFalse, _importFunc, _exportFunc, _fillChar, _throwOnColumnOverflow);
         }
 
         /// <summary>
@@ -127,6 +129,17 @@ namespace AsciiImportExport
         {
             _stringFormat = stringFormat;
             return this;
+        }
+
+        public DocumentColumnBuilder<T, TRet> SetFillChar(char fillChar)
+        {
+            _fillChar = fillChar;
+            return this;
+        }
+
+        public void ThrowOnOverflow()
+        {
+            _throwOnColumnOverflow = true;
         }
     }
 }

--- a/AsciiImportExport/DocumentFormatDefinition.cs
+++ b/AsciiImportExport/DocumentFormatDefinition.cs
@@ -19,8 +19,9 @@ namespace AsciiImportExport
         private readonly string _headerLinePraefix;
         private readonly Func<T> _instantiator;
         private readonly bool _lineEndsWithColumnSeparator;
+        private readonly bool _trimLineEnds;
 
-        public DocumentFormatDefinition(List<IDocumentColumn<T>> columns, string columnSeparator, string commentString, bool autosizeColumns, bool exportHeaderLine, string headerLinePraefix, Func<T> instantiator, bool lineEndsWithColumnSeparator)
+        public DocumentFormatDefinition(List<IDocumentColumn<T>> columns, string columnSeparator, string commentString, bool autosizeColumns, bool exportHeaderLine, string headerLinePraefix, Func<T> instantiator, bool lineEndsWithColumnSeparator, bool trimLineEnds)
         {
             _columns = columns;
 
@@ -34,6 +35,7 @@ namespace AsciiImportExport
             _headerLinePraefix = headerLinePraefix ?? "";
             _instantiator = instantiator;
             _lineEndsWithColumnSeparator = lineEndsWithColumnSeparator;
+            _trimLineEnds = trimLineEnds;
         }
 
         public string ColumnSeparator { get; private set; }
@@ -120,7 +122,12 @@ namespace AsciiImportExport
                     if (j < _columns.Count - 1 || _lineEndsWithColumnSeparator)
                         lineSb.Append(ColumnSeparator);
                 }
-                sb.AppendLine(lineSb.ToString().TrimEnd());
+                var line = lineSb.ToString();
+                if (_trimLineEnds)
+                {
+                    line = line.TrimEnd();
+                }
+                sb.AppendLine(line);
             }
 
             return sb.ToString().TrimEnd('\r', '\n');

--- a/AsciiImportExport/DocumentFormatDefinitionBuilder.cs
+++ b/AsciiImportExport/DocumentFormatDefinitionBuilder.cs
@@ -22,6 +22,7 @@ namespace AsciiImportExport
         private Func<T> _instantiator;
         private bool _lineEndsWithColumnSeparator;
         private string _headerLinePraefix;
+        private bool _trimLineEnds = true;
 
 
         /// <summary>
@@ -133,7 +134,7 @@ namespace AsciiImportExport
         /// <returns></returns>
         public IDocumentFormatDefinition<T> Build()
         {
-            return new DocumentFormatDefinition<T>(_columns, _columnSeparator, _commentString, _autosizeColumns, _exportHeaderLine, _headerLinePraefix, _instantiator, _lineEndsWithColumnSeparator);
+            return new DocumentFormatDefinition<T>(_columns, _columnSeparator, _commentString, _autosizeColumns, _exportHeaderLine, _headerLinePraefix, _instantiator, _lineEndsWithColumnSeparator, _trimLineEnds);
         }
 
         /// <summary>
@@ -173,6 +174,12 @@ namespace AsciiImportExport
         public DocumentFormatDefinitionBuilder<T> SetLineEndsWithColumnSeparator(bool lineEndsWithColumnSeparator)
         {
             _lineEndsWithColumnSeparator = lineEndsWithColumnSeparator;
+            return this;
+        }
+
+        public DocumentFormatDefinitionBuilder<T> SetTrimLineEnds(bool trimLineEnds)
+        {
+            _trimLineEnds = trimLineEnds;
             return this;
         }
     }


### PR DESCRIPTION
Hi, I've implemented a few specific features, which are required for export format I am targeting for:
- Custom fill char for fields (e.g. zero filled, right justified account number)
- Column length overflow data validation
- Option to disable trimming trailing spaces in the line

It would be awesome if you can push them to next nuget package, so I won't need to use local nuget feed for this.
